### PR TITLE
Correção parágrafo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-VTEX Speed
-=====
+# VTEX Speed
 
 VTEX Store development tools - reverse proxy, compilation, minification, optimization and more!
 


### PR DESCRIPTION
Nos outros parágrafos foi utilizado **##** que é o correto para essa aplicação, mas no "H1" ele estava incorreto pois um "#" equivale ao "H1" para parágrafos mesmo.
Com essa alteração mantém o padrão e mantém o mesmo visual para os leitores.