### PR TITLE
Correção para funcionamento com contas com urls full HTTPS

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -10,16 +10,18 @@ module.exports = (grunt) ->
   accountName = process.env.VTEX_ACCOUNT or pkg.accountName or 'basedevmkp'
 
   environment = process.env.VTEX_ENV or 'vtexcommercestable'
+  
+  secureUrl = process.env.VTEX_SECURE_URL or pkg.secureUrl
 
   verbose = grunt.option('verbose')
 
-  imgProxyOptions = url.parse("http://#{accountName}.vteximg.com.br/arquivos")
+  imgProxyOptions = url.parse("https://#{accountName}.vteximg.com.br/arquivos")
   imgProxyOptions.route = '/arquivos'
 
   # portalHost is also used by connect-http-please
   # example: basedevmkp.vtexcommercestable.com.br
   portalHost = "#{accountName}.#{environment}.com.br"
-  portalProxyOptions = url.parse("http://#{portalHost}/")
+  portalProxyOptions = url.parse("https://#{portalHost}/")
   portalProxyOptions.preserveHost = true
 
   rewriteLocation = (location) ->
@@ -105,7 +107,7 @@ module.exports = (grunt) ->
             middlewares.disableCompression
             middlewares.rewriteLocationHeader(rewriteLocation)
             middlewares.replaceHost(portalHost)
-            middlewares.replaceHtmlBody(environment)
+            middlewares.replaceHtmlBody(environment, accountName, secureUrl)
             httpPlease(host: portalHost, verbose: verbose)
             serveStatic('./build')
             proxy(imgProxyOptions)

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -15,7 +15,11 @@ module.exports = (grunt) ->
 
   verbose = grunt.option('verbose')
 
-  imgProxyOptions = url.parse("https://#{accountName}.vteximg.com.br/arquivos")
+  if secureUrl
+    imgProxyOptions = url.parse("https://#{accountName}.vteximg.com.br/arquivos")
+  else 
+    imgProxyOptions = url.parse("http://#{accountName}.vteximg.com.br/arquivos")
+
   imgProxyOptions.route = '/arquivos'
 
   # portalHost is also used by connect-http-please

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vtex-speed",
   "version": "4.0.0",
+  "secureUrl": true,
   "readmeFilename": "README.md",
   "description": "VTEX Store development tools - reverse proxy, compilation, minification, optimization and more!",
   "scripts": {


### PR DESCRIPTION
Feita correção e adicionada opção no package.json para funcionamento do VTEX Speed com lojas que rodam full HTTPS, citada em #32 .

O parâmetro `secureUrl` foi adicionado no package.json, podem receber valores `true` ou `false`.

@klzns @firstdoit Acredito que esse PR pode ajudar bastante o ecossistema de desenvolvedores VTEX.

O "pulo do gato" era manipular o header da resposta. Créditos ao [@schmite](https://github.com/schmite) por descobrir o header correto. 