### PR TITLE
Change structure to accept multistore

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -191,6 +191,8 @@ module.exports = (grunt) ->
             middlewares.replaceHost(portalHost)
             middlewares.replaceReferer(rewriteReferer)
             middlewares.replaceHtmlBody(environment, accountName, secureUrl, port)
+            # middlewares.replaceHtmlBody(environment, accountName, secureUrl, port, 'myChildAccountName')
+            middlewares.replaceHtmlBody(environment, accountName, secureUrl, port)
             httpPlease(host: portalHost, verbose: verbose)
             serveStatic('./build')
             proxy(imgProxyOptions)

--- a/speed-middleware.coffee
+++ b/speed-middleware.coffee
@@ -3,7 +3,7 @@ ignoreReplace = [/\.js(\?.*)?$/, /\.css(\?.*)?$/, /\.svg(\?.*)?$/, /\.ico(\?.*)?
 
 # Middleware that replaces vtexcommercestable and vteximg for vtexlocal
 # This enables the same proxy to handle both domains and avoid adding rules to /etc/hosts
-replaceHtmlBody = (environment, accountName, secureUrl, port) -> (req, res, next) ->
+replaceHtmlBody = (environment, accountNameMain, secureUrl, port, accountNameChild) -> (req, res, next) ->
   # Ignore requests to obvious non-HTML resources
   return next() if ignoreReplace.some (ignore) -> ignore.test(req.url)
 
@@ -29,7 +29,9 @@ replaceHtmlBody = (environment, accountName, secureUrl, port) -> (req, res, next
       data = data.replace(new RegExp(environment, "g"), "vtexlocal")
       data = data.replace(new RegExp("vteximg", "g"), "vtexlocal")
       if secureUrl
-        data = data.replace(new RegExp("https:\/\/"+accountName, "g"), "http://"+accountName)
+        data = data.replace(new RegExp("https:\/\/"+accountNameMain, "g"), "http://"+accountNameMain)
+      if accountNameChild && secureUrl
+        data = data.replace(new RegExp("https:\/\/"+accountNameChild, "g"), "http://"+accountNameChild)
 
     if port isnt 80
       data = data.replace(new RegExp("vtexlocal.com.br\/", "g"), "vtexlocal.com.br:#{port}\/")


### PR DESCRIPTION
Hi,
This solution allows the use of vtexlocal in a multistore structure. 
If your account is multistore some files may come from the parent store, so when using vtexlocal it will not work, because it will replace only the https of the child account.
In my solution if you have a child account you should pass a new parameter to the function `replaceHtmlBody` with your child account name. It will allow the correct replacement.
